### PR TITLE
Mistral: Fix typo, update verification requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ This lists various services that provide free access or credits towards API-base
             <td>Liquid LFM 40B</td>
             <td></td>
         </tr><tr>
-        <td><a href="https://console.mistral.ai/" target="_blank">Mistral (Le Platforme)</a></td>
-        <td>Free tier (Experiment plan) requires opting into data training.</td>
+        <td><a href="https://console.mistral.ai/" target="_blank">Mistral (La Plateforme)</a></td>
+        <td>Free tier (Experiment plan) requires opting into data training, requires phone number verification.</td>
         <td>Open and Proprietary Mistral models</td>
         <td>1 request/second<br>500,000 tokens/minute<br>1,000,000,000 tokens/month</td>
     </tr><tr>


### PR DESCRIPTION
I just signed up, so I can confirm that it requires phone number verification.