### PR TITLE
feat: Add credit requirements for Modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,8 @@ Very stringent payment verification for Google Cloud.
 
 **Credits:** $30/month
 
+**Requirements:** Get $5 in credits upon Sign Up. Add a default payment method to unlock an additional $25.
+
 **Models:** Any supported model - pay by compute time
 
 ### [Hyperbolic](https://app.hyperbolic.xyz/)


### PR DESCRIPTION
Changes:
- Added **Requirements** sub-section under the **Modal** (LLM Provider).

Details:
Upon Signing Up with **Modal**, you will have $5 in credits available. A default payment method is required to unlock an additional $25.
![image](https://github.com/user-attachments/assets/d937063c-900b-45be-b778-7ff48296cc0e)
