### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pip install -r src/requirements.txt
       - id: "auth"
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           workload_identity_provider: "projects/576328904266/locations/global/workloadIdentityPools/github/providers/cheahjs-org"
           project_id: ${{ secrets.GCP_PROJECT }}
@@ -45,7 +45,7 @@ jobs:
         run: |
           rm ${{ steps.auth.outputs.credentials_file_path }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           title: "Update README with latest models"
           body: "This PR updates the README with the latest available models."


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `google-github-actions/auth` | [`v2`](https://github.com/google-github-actions/auth/releases/tag/v2) | [`v3`](https://github.com/google-github-actions/auth/releases/tag/v3) | [Release](https://github.com/google-github-actions/auth/releases/tag/v3) | update-readme.yml |
| `peter-evans/create-pull-request` | [`v7`](https://github.com/peter-evans/create-pull-request/releases/tag/v7) | [`v8`](https://github.com/peter-evans/create-pull-request/releases/tag/v8) | [Release](https://github.com/peter-evans/create-pull-request/releases/tag/v8) | update-readme.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
