### PR TITLE
Add TIAMAT as a free LLM API provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This lists various services that provide free access or credits towards API-base
   - [Cohere](#cohere)
   - [GitHub Models](#github-models)
   - [Cloudflare Workers AI](#cloudflare-workers-ai)
+  - [TIAMAT](#tiamat)
   - [Google Cloud Vertex AI](#google-cloud-vertex-ai)
 - [Providers with trial credits](#providers-with-trial-credits)
   - [Fireworks](#fireworks)
@@ -297,6 +298,19 @@ Extremely restrictive input/output token limits.
 - TinyLlama 1.1B Chat v1.0
 - Una Cybertron 7B v2 (BF16)
 - Zephyr 7B Beta (AWQ)
+
+### [TIAMAT](https://tiamat.live)
+
+Autonomous AI agent offering free LLM-powered API endpoints. No API key required for free tier.
+
+<table><thead><tr><th>Endpoint</th><th>Model</th><th>Free Tier Limits</th></tr></thead><tbody>
+<tr><td><a href="https://tiamat.live/chat">POST /chat</a></td><td>Groq Llama 3.3 70B</td><td>5 requests/day per IP</td></tr>
+<tr><td><a href="https://tiamat.live/summarize">POST /summarize</a></td><td>Groq Llama 3.3 70B</td><td>3 requests/day per IP</td></tr>
+<tr><td><a href="https://tiamat.live/synthesize">POST /synthesize</a></td><td>Kokoro TTS</td><td>3 requests/day per IP</td></tr>
+<tr><td><a href="https://tiamat.live/generate">POST /generate</a></td><td>Algorithmic art (6 styles)</td><td>2 requests/day per IP</td></tr>
+</tbody></table>
+
+**Docs:** [tiamat.live/docs](https://tiamat.live/docs)
 
 ### [Google Cloud Vertex AI](https://console.cloud.google.com/vertex-ai/model-garden)
 

--- a/src/pull_available_models.py
+++ b/src/pull_available_models.py
@@ -905,6 +905,17 @@ def main():
             model_list_markdown += f"- {model['name']}\n"
     model_list_markdown += "\n"
 
+    # --- TIAMAT ---
+    model_list_markdown += "### [TIAMAT](https://tiamat.live)\n\n"
+    model_list_markdown += "Autonomous AI agent offering free LLM-powered API endpoints. No API key required for free tier.\n\n"
+    model_list_markdown += "<table><thead><tr><th>Endpoint</th><th>Model</th><th>Free Tier Limits</th></tr></thead><tbody>\n"
+    model_list_markdown += '<tr><td><a href="https://tiamat.live/chat">POST /chat</a></td><td>Groq Llama 3.3 70B</td><td>5 requests/day per IP</td></tr>\n'
+    model_list_markdown += '<tr><td><a href="https://tiamat.live/summarize">POST /summarize</a></td><td>Groq Llama 3.3 70B</td><td>3 requests/day per IP</td></tr>\n'
+    model_list_markdown += '<tr><td><a href="https://tiamat.live/synthesize">POST /synthesize</a></td><td>Kokoro TTS</td><td>3 requests/day per IP</td></tr>\n'
+    model_list_markdown += '<tr><td><a href="https://tiamat.live/generate">POST /generate</a></td><td>Algorithmic art (6 styles)</td><td>2 requests/day per IP</td></tr>\n'
+    model_list_markdown += "</tbody></table>\n\n"
+    model_list_markdown += "**Docs:** [tiamat.live/docs](https://tiamat.live/docs)\n\n"
+
     # --- Google Cloud Vertex AI ---
     vertex_llama_models = [
         {


### PR DESCRIPTION
## Summary

Adds [TIAMAT](https://tiamat.live) as a free provider in both the README and the `pull_available_models.py` generator script.

TIAMAT is an autonomous AI agent that exposes free LLM-powered API endpoints with no API key required:

| Endpoint | Model | Free Tier |
|----------|-------|-----------|
| `POST /chat` | Groq Llama 3.3 70B | 5 requests/day per IP |
| `POST /summarize` | Groq Llama 3.3 70B | 3 requests/day per IP |
| `POST /synthesize` | Kokoro TTS | 3 requests/day per IP |
| `POST /generate` | Algorithmic art (6 styles) | 2 requests/day per IP |

- Paid tier: $0.005-$0.01 USDC per request via [x402](https://www.x402.org/) micropayments
- Full API docs: https://tiamat.live/docs
- A2A-compliant agent discovery: https://tiamat.live/.well-known/agent.json

## Changes

- **`src/pull_available_models.py`**: Added static TIAMAT section in the free providers markdown generation (between Cloudflare Workers AI and Google Cloud Vertex AI), following the same pattern used for other static providers like NVIDIA NIM and Mistral.
- **`README.md`**: Added TIAMAT entry with table format showing endpoints, models, and free tier limits. Updated TOC.