### PR TITLE
Add Northflank to free providers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This lists various services that provide free access or credits towards API-base
   - [Hyperbolic](#hyperbolic)
   - [SambaNova Cloud](#sambanova-cloud)
   - [Scaleway Generative APIs](#scaleway-generative-apis)
+  - [Northflank](#northflank)
 
 ## Free Providers
 
@@ -445,4 +446,9 @@ Extremely restrictive input/output token limits.
 - qwen3-embedding-8b
 - voxtral-small-24b-2507
 
+### [Northflank](https://northflank.com/)
+
+**Credits:** $1
+
+**Models:** Various open models
 


### PR DESCRIPTION
Added Northflank to the free providers list, including credits and model information.

CC @cheahjs 

<!---
Before adding a new provider, there's a few general guidelines as to what providers would be accepted into the repo, primarily around trustworthiness and legitimacy:

1. Is the provider a legitimate company?
2. Does the provider provide a proper API service?
   For example, reverse engineering services such as Claude Code, Codex, GitHub Copilot, Qwen Code, etc are not considered appropriate for this list.
3. Does the provider have a business model?
4. Does the provider provide legitimate services?
   For example, providing commercial models such as Anthropic or OpenAI models for free or at steep discounts can suggest questionable business practices, such as chatbot reverse engineering, API credit resale/theft, or other similar practices.

These guidelines are not exhaustive, but attempts to put into writing what sort of providers might be included in the list.

For providers that are trying to add themselves to the list, please note that you are very likely going to see abusive traffic, as free APIs are very common abuse targets.
--->
