### PR TITLE
Add QuickSilver Pro to trial-credit providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This lists various services that provide free access or credits towards API-base
   - [Alibaba Cloud (International) Model Studio](#alibaba-cloud-international-model-studio)
   - [Modal](#modal)
   - [Inference.net](#inferencenet)
+  - [QuickSilver Pro](#quicksilver-pro)
   - [Hyperbolic](#hyperbolic)
   - [SambaNova Cloud](#sambanova-cloud)
   - [Scaleway Generative APIs](#scaleway-generative-apis)
@@ -371,6 +372,12 @@ Extremely restrictive input/output token limits.
 **Credits:** $1, $25 on responding to email survey
 
 **Models:** Various open models
+
+### [QuickSilver Pro](https://quicksilverpro.io)
+
+**Credits:** $0.10 free on sign-up
+
+**Models:** DeepSeek V3, DeepSeek R1, Qwen3.5-35B-A3B (OpenAI-compatible)
 
 ### [Hyperbolic](https://app.hyperbolic.ai/)
 

--- a/src/pull_available_models.py
+++ b/src/pull_available_models.py
@@ -1008,6 +1008,13 @@ def main():
             "requirements": "",
             "models_desc": "Various open models",
         },
+        {
+            "name": "QuickSilver Pro",
+            "url": "https://quicksilverpro.io",
+            "credits": "$0.10 free on sign-up",
+            "requirements": "",
+            "models_desc": "DeepSeek V3, DeepSeek R1, Qwen3.5-35B-A3B (OpenAI-compatible)",
+        },
     ]
 
     for provider in trial_providers_static:


### PR DESCRIPTION
## Summary

Adds [QuickSilver Pro](https://quicksilverpro.io) to the **Providers with trial credits** section.

- OpenAI-compatible API for three open-source models: DeepSeek V3, DeepSeek R1, Qwen3.5-35B-A3B.
- $0.10 free credit on sign-up — same trial-credit category as Fireworks (\$1) / Novita (\$0.50).

## Changes

- `src/pull_available_models.py` — adds a dict entry to \`trial_providers_static\`, the source of truth for this section.
- `README.md` — mirror entry so it renders immediately without waiting for the next generator run. Same format as surrounding entries.

## Disclosure

I'm affiliated with QuickSilver Pro. Happy to adjust wording / position / ordering if it doesn't match the list's conventions — just let me know.