### PR TITLE
Update Cerebras preview model limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Free models may use data for improvement.
 ### [Cerebras](https://cloud.cerebras.ai/)
 
 <table><thead><tr><th>Model Name</th><th>Model Limits</th></tr></thead><tbody>
-<tr><td>gpt-oss-120b</td><td>30 requests/minute<br>60,000 tokens/minute<br>900 requests/hour<br>1,000,000 tokens/hour<br>14,400 requests/day<br>1,000,000 tokens/day</td></tr>
+<tr><td>Qwen 3 235B Instruct</td><td>5 requests/minute<br>30,000 tokens/minute<br>900 requests/hour<br>1,000,000 tokens/hour<br>14,400 requests/day<br>1,000,000 tokens/day</td></tr>
 <tr><td>Llama 3.1 8B</td><td>30 requests/minute<br>60,000 tokens/minute<br>900 requests/hour<br>1,000,000 tokens/hour<br>14,400 requests/day<br>1,000,000 tokens/day</td></tr>
 </tbody></table>
 

--- a/src/pull_available_models.py
+++ b/src/pull_available_models.py
@@ -840,8 +840,8 @@ def main():
     model_list_markdown += "<table><thead><tr><th>Model Name</th><th>Model Limits</th></tr></thead><tbody>\n"
     cerebras_models = [
         {
-            "name": "gpt-oss-120b",
-            "limits_text": "30 requests/minute<br>60,000 tokens/minute<br>900 requests/hour<br>1,000,000 tokens/hour<br>14,400 requests/day<br>1,000,000 tokens/day"
+            "name": "Qwen 3 235B Instruct",
+            "limits_text": "5 requests/minute<br>30,000 tokens/minute<br>900 requests/hour<br>1,000,000 tokens/hour<br>14,400 requests/day<br>1,000,000 tokens/day"
         },
         {
             "name": "Llama 3.1 8B",


### PR DESCRIPTION
Update the generated Cerebras entry to replace `gpt-oss-120b` with `Qwen 3 235B Instruct` and apply the current rate limits from Cerebras' model overview.

According to https://inference-docs.cerebras.ai/models/overview, the free tiers for `zai-glm-4.7` and `gpt-oss-120b` have been temporarily reduced, and `llama3.1-8b` plus `qwen-3-235b-a22b-instruct-2507` are scheduled for deprecation on May 27, 2026.