### PR TITLE
Add OfoxAI as free provider

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -262,6 +262,7 @@ MODEL_TO_NAME_MAPPING = {
     "compound-beta-mini": "Groq compound-beta-mini",
     "compound-beta": "Groq compound-beta",
     "shisa-ai/shisa-v2-llama3.3-70b": "Shisa V2 Llama 3.3 70B",
+    "z-ai/glm-4.7-flash:free": "GLM-4.7-Flash",
 }
 
 HYPERBOLIC_IGNORED_MODELS = {

--- a/src/pull_available_models.py
+++ b/src/pull_available_models.py
@@ -239,6 +239,35 @@ def fetch_openrouter_models(logger):
     return ret_models
 
 
+def fetch_ofoxai_models(logger):
+    logger.info("Fetching OfoxAI models...")
+    api_key = os.environ.get("OFOXAI_API_KEY", "")
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    r = requests.get("https://api.ofox.ai/v1/models", headers=headers)
+    r.raise_for_status()
+    models = r.json()["data"]
+    logger.info(f"Fetched {len(models)} models from OfoxAI")
+    ret_models = []
+    for model in models:
+        if ":free" not in model["id"]:
+            continue
+        pricing = float(model.get("pricing", {}).get("completion", "1")) + float(
+            model.get("pricing", {}).get("prompt", "1")
+        )
+        if pricing != 0:
+            continue
+        ret_models.append(
+            {
+                "id": model["id"],
+                "name": get_model_name(model["id"]),
+            }
+        )
+    ret_models = sorted(ret_models, key=lambda x: x["name"])
+    return ret_models
+
+
 def fetch_cloudflare_models(logger):
     logger.info("Fetching Cloudflare models...")
     r = requests.get(
@@ -639,6 +668,7 @@ def main():
     logger = create_logger("Main")
     groq_logger = create_logger("Groq")
     openrouter_logger = create_logger("OpenRouter")
+    ofoxai_logger = create_logger("OfoxAI")
     google_ai_studio_logger = create_logger("Google AI Studio")
     cloudflare_logger = create_logger("Cloudflare")
     github_logger = create_logger("GitHub")
@@ -654,6 +684,7 @@ def main():
             futures = [
                 executor.submit(fetch_gemini_limits, google_ai_studio_logger),
                 executor.submit(fetch_openrouter_models, openrouter_logger),
+                executor.submit(fetch_ofoxai_models, ofoxai_logger),
                 executor.submit(fetch_hyperbolic_models, hyperbolic_logger),
                 executor.submit(fetch_cloudflare_models, cloudflare_logger),
                 executor.submit(fetch_github_models, github_logger),
@@ -664,6 +695,7 @@ def main():
             (
                 gemini_models,
                 openrouter_models,
+                ofoxai_models,
                 hyperbolic_models,
                 cloudflare_models,
                 github_models,
@@ -677,6 +709,7 @@ def main():
     else:
         gemini_models = fetch_gemini_limits(google_ai_studio_logger)
         openrouter_models = fetch_openrouter_models(openrouter_logger)
+        ofoxai_models = fetch_ofoxai_models(ofoxai_logger)
         hyperbolic_models = fetch_hyperbolic_models(hyperbolic_logger)
         cloudflare_models = fetch_cloudflare_models(cloudflare_logger)
         github_models = fetch_github_models(github_logger)
@@ -699,6 +732,15 @@ def main():
             model_list_markdown += (
                 f"- [{model['name']}](https://openrouter.ai/{model['id']})\n"
             )
+    model_list_markdown += "\n"
+
+    # --- OfoxAI ---
+    model_list_markdown += "### [OfoxAI](https://ofox.ai)\n\n"
+    model_list_markdown += "Unified API gateway for 100+ LLMs. OpenAI and Anthropic SDK-compatible. China-friendly with Hong Kong direct access routes.\n\n"
+    if ofoxai_models:
+        model_list_markdown += "**Limits:** Not published\n\n"
+        for model in ofoxai_models:
+            model_list_markdown += f"- [{model['name']}](https://ofox.ai/models/{model['id']})\n"
     model_list_markdown += "\n"
 
     # --- Google AI Studio ---


### PR DESCRIPTION
## Add OfoxAI

**Website:** https://ofox.ai

### What is OfoxAI?

OfoxAI is a unified API gateway for 100+ LLMs. It provides an OpenAI and Anthropic SDK-compatible endpoint, making it easy to switch between models without changing code. It is particularly useful for users in China as it provides direct access via Hong Kong routes.

### Free model

OfoxAI offers `z-ai/glm-4.7-flash:free` (GLM-4.7-Flash by Zhipu AI) with:
- Input: $0/M tokens
- Output: $0/M tokens
- Context: 200K
- Max output: 128K

Base URL: `https://api.ofox.ai/v1`

### Changes

- `src/data.py`: Added model name mapping for `z-ai/glm-4.7-flash:free`
- `src/pull_available_models.py`: Added `fetch_ofoxai_models()` function and wired it into both concurrent and sequential execution paths, plus markdown generation

### Note on rate limits

OfoxAI does not currently publish rate limits for the free model. The PR marks them as "Not published" — happy to update once confirmed.

### Note on API key

The fetch function uses `OFOXAI_API_KEY` env var if set, but also works without one if the `/v1/models` endpoint is public. Please let me know if you need a key for CI.