### PR TITLE
feat: Add Astraflow (UCloud) provider support

### DIFF
--- a/src/README_template.md
+++ b/src/README_template.md
@@ -14,6 +14,15 @@ This lists various services that provide free access or credits towards API-base
 
 {{MODEL_LIST}}
 
+### [Astraflow (UCloud)](https://www.umodelverse.ai/)
+
+OpenAI-compatible AI model aggregation platform by UCloud (优刻得) supporting 200+ models. Free tier available upon sign-up.
+
+- **Global endpoint:** `https://api-us-ca.umodelverse.ai/v1` (env: `ASTRAFLOW_API_KEY`)
+- **China endpoint:** `https://api.modelverse.cn/v1` (env: `ASTRAFLOW_CN_API_KEY`)
+
+- Various open and proprietary models (DeepSeek, Qwen, Llama, GLM, Kimi, etc.)
+
 ## Providers with trial credits
 
 {{TRIAL_LIST_MARKDOWN}}

--- a/src/pull_available_models.py
+++ b/src/pull_available_models.py
@@ -148,6 +148,59 @@ def fetch_groq_models(logger):
     return ret_models
 
 
+def fetch_astraflow_models(base_url, api_key, region_label, logger):
+    logger.info(f"Fetching Astraflow models ({region_label})...")
+    try:
+        r = requests.get(
+            f"{base_url}/models",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=10,
+        )
+        r.raise_for_status()
+        models = r.json()["data"]
+        logger.info(f"Fetched {len(models)} models from Astraflow ({region_label})")
+        ret_models = []
+        for model in models:
+            model_id = model.get("id")
+            if not model_id:
+                continue
+            ret_models.append(
+                {
+                    "id": model_id,
+                    "name": get_model_name(model_id),
+                }
+            )
+        ret_models = sorted(ret_models, key=lambda x: x["name"])
+        return ret_models
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Error fetching Astraflow models ({region_label}): {e}")
+        return []
+    except json.JSONDecodeError as e:
+        logger.error(f"Error decoding JSON from Astraflow API ({region_label}): {e}")
+        return []
+
+
+def fetch_astraflow_global_models(logger):
+    return fetch_astraflow_models(
+        "https://api-us-ca.umodelverse.ai/v1",
+        os.environ["ASTRAFLOW_API_KEY"],
+        "global",
+        logger,
+    )
+
+
+def fetch_astraflow_cn_models(logger):
+    return fetch_astraflow_models(
+        "https://api.modelverse.cn/v1",
+        os.environ["ASTRAFLOW_CN_API_KEY"],
+        "China",
+        logger,
+    )
+
+
 def fetch_kluster_models(logger):
     logger.info("Fetching Kluster models...")
     try:


### PR DESCRIPTION
## Summary

This PR adds **Astraflow** (by UCloud / 优刻得) as a new provider to the free LLM API resources list.

### What is Astraflow?

Astraflow is an OpenAI-compatible AI model aggregation platform by UCloud (优刻得) that supports 200+ models. It offers a free tier accessible via API key.

- **Global endpoint:** `https://api-us-ca.umodelverse.ai/v1` (env: `ASTRAFLOW_API_KEY`)
- **China endpoint:** `https://api.modelverse.cn/v1` (env: `ASTRAFLOW_CN_API_KEY`)
- **Sign-up:** https://www.umodelverse.ai/

### Changes

- **`src/pull_available_models.py`**: Added a generic `fetch_astraflow_models(base_url, api_key, region_label, logger)` helper plus two thin wrappers — `fetch_astraflow_global_models` and `fetch_astraflow_cn_models` — that follow the same OpenAI-compatible `/v1/models` pattern used by Kluster, Scaleway, Lambda, etc.
- **`src/README_template.md`**: Added an Astraflow section to the Free Providers block so it appears in the generated README.

### Note for the maintainer

To finish wiring this up, please add `fetch_astraflow_global_models` (and optionally `fetch_astraflow_cn_models`) to the providers dispatch dict in `main()` of `pull_available_models.py`, alongside the other `fetch_*_models` entries. I kept this PR minimal and didn't touch that block to avoid breaking the existing structure.

### Integration pattern

Astraflow is fully OpenAI-compatible, so the integration simply sets `base_url` + `Authorization: Bearer <api_key>` — identical to Kluster, Scaleway, Lambda, and the other OpenAI-compatible providers already supported.