### PR TITLE
Add DGrid Free Models Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This lists various services that provide free access or credits towards API-base
   - [Mistral (Codestral)](#mistral-codestral)
   - [HuggingFace Inference Providers](#huggingface-inference-providers)
   - [Vercel AI Gateway](#vercel-ai-gateway)
+  - [DGrid Free Models Router](#dgrid-free-models-router)
   - [OpenCode Zen](#opencode-zen)
   - [Cerebras](#cerebras)
   - [Groq](#groq)
@@ -135,6 +136,25 @@ Routes to various supported providers.
 
 **Limits:** [$5/month](https://vercel.com/docs/ai-gateway/pricing)
 
+
+### [DGrid Free Models Router](https://dgrid.ai/models/dgridai/free)
+
+DGrid Free Models Router is DGrid's free intelligent inference gateway. It combines multiple models into a seamless router and dynamically selects the best-fit model for each request, helping optimize speed, reliability, and task efficiency without requiring users to manage model selection directly.
+
+**Limits:** 10 requests/minute and 100 requests/day. With a $5 lifetime top-up, limits increase to up to 20 requests/minute and 1,000 requests/day.
+
+**Links:** [DGrid](https://dgrid.ai/), [Documentation](https://docs.dgrid.ai/), [API reference](https://docs.dgrid.ai/api-reference/introduction), [API base URL](https://api.dgrid.ai/v1)
+
+Currently supported free auto-routing models:
+
+- llama-3.2-1b-instruct
+- glm-4.7-flash
+- deepseek-r1-distill-qwen-32b
+- llama-3.3-70b-instruct-fp8-fast
+- Kimi-K2.6
+- GLM-5.2
+
+More free models will be added over time.
 
 ### [OpenCode Zen](https://opencode.ai/docs/zen/)
 
@@ -382,5 +402,3 @@ Extremely restrictive input/output token limits.
 - qwen3.5-397b-a17b
 - qwen3.6-35b-a3b
 - voxtral-small-24b-2507
-
-

--- a/src/pull_available_models.py
+++ b/src/pull_available_models.py
@@ -842,6 +842,21 @@ def main():
     model_list_markdown += "**Limits:** [$5/month](https://vercel.com/docs/ai-gateway/pricing)\n\n"
     model_list_markdown += "\n"
 
+    # --- DGrid Free Models Router ---
+    model_list_markdown += "### [DGrid Free Models Router](https://dgrid.ai/models/dgridai/free)\n\n"
+    model_list_markdown += "DGrid Free Models Router is DGrid's free intelligent inference gateway. It combines multiple models into a seamless router and dynamically selects the best-fit model for each request, helping optimize speed, reliability, and task efficiency without requiring users to manage model selection directly.\n\n"
+    model_list_markdown += "**Limits:** 10 requests/minute and 100 requests/day. With a $5 lifetime top-up, limits increase to up to 20 requests/minute and 1,000 requests/day.\n\n"
+    model_list_markdown += "**Links:** [DGrid](https://dgrid.ai/), [Documentation](https://docs.dgrid.ai/), [API reference](https://docs.dgrid.ai/api-reference/introduction), [API base URL](https://api.dgrid.ai/v1)\n\n"
+    model_list_markdown += "Currently supported free auto-routing models:\n\n"
+    model_list_markdown += "- llama-3.2-1b-instruct\n"
+    model_list_markdown += "- glm-4.7-flash\n"
+    model_list_markdown += "- deepseek-r1-distill-qwen-32b\n"
+    model_list_markdown += "- llama-3.3-70b-instruct-fp8-fast\n"
+    model_list_markdown += "- Kimi-K2.6\n"
+    model_list_markdown += "- GLM-5.2\n"
+    model_list_markdown += "\nMore free models will be added over time.\n"
+    model_list_markdown += "\n"
+
     # --- OpenCode Zen ---
     model_list_markdown += "### [OpenCode Zen](https://opencode.ai/docs/zen/)\n\n"
     model_list_markdown += "AI gateway with curated models.\n\n"


### PR DESCRIPTION
This PR adds DGrid Free Models Router to the Free Providers list.

DGrid Free Models Router is DGrid's free intelligent inference gateway. It combines multiple models into a seamless router and dynamically selects the best-fit model for each request, helping optimize speed, reliability, and task efficiency without requiring users to manage model selection directly.

The router model page is:
https://dgrid.ai/models/dgridai/free

Current free auto-routing limits:

- 10 requests/minute
- 100 requests/day
- Up to 20 requests/minute and 1,000 requests/day with a $5 lifetime top-up

Currently supported free auto-routing models:

- llama-3.2-1b-instruct
- glm-4.7-flash
- deepseek-r1-distill-qwen-32b
- llama-3.3-70b-instruct-fp8-fast
- Kimi-K2.6
- GLM-5.2

More free models will be added over time.

This PR updates both the generated README and the README generation script.