### PR TITLE
Add Starveri API trial provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,12 @@ Extremely restrictive input/output token limits.
 
 **Models:** Various open models
 
+### [Starveri API](https://api.starveri.net/docs)
+
+**Credits:** 5 text-only demo requests before purchase; paid usage requires prepaid credits
+
+**Models:** [OpenAI-compatible GPT/Codex API gateway](https://api.starveri.net/models)
+
 ### [Hyperbolic](https://app.hyperbolic.ai/)
 
 **Credits:** $1
@@ -382,5 +388,4 @@ Extremely restrictive input/output token limits.
 - qwen3.5-397b-a17b
 - qwen3.6-35b-a3b
 - voxtral-small-24b-2507
-
 

--- a/src/pull_available_models.py
+++ b/src/pull_available_models.py
@@ -1024,6 +1024,13 @@ def main():
             "requirements": "",
             "models_desc": "Various open models",
         },
+        {
+            "name": "Starveri API",
+            "url": "https://api.starveri.net/docs",
+            "credits": "5 text-only demo requests before purchase; paid usage requires prepaid credits",
+            "requirements": "",
+            "models_desc": "[OpenAI-compatible GPT/Codex API gateway](https://api.starveri.net/models)",
+        },
     ]
 
     for provider in trial_providers_static:


### PR DESCRIPTION
Summary:
- Adds Starveri API to the provider list with its trial request limit and prepaid-credit note.
- Updates the generated README entry to match the source metadata.

Testing:
- git diff --check
- rg "Starveri" src/pull_available_models.py README.md

Fixes #330

AI assistance: This documentation/data update was prepared with AI assistance and reviewed before submission.
