### PR TITLE
Add a cheapest-paid-price tip to the README template

### DIFF
--- a/src/README_template.md
+++ b/src/README_template.md
@@ -8,6 +8,9 @@ This lists various services that provide free access or credits towards API-base
 > [!WARNING]  
 > This list explicitly excludes any services that are not legitimate (eg reverse engineers an existing chatbot)
 
+> [!TIP]  
+> Hit a free tier's rate limit or quota? [ModelPriceWatch](https://modelpricewatch.com/cheapest/) tracks the live cheapest *paid* input price across LLM APIs, auto-updated from provider pricing pages — useful for picking the cheapest paid fallback.
+
 {{TOC}}
 
 ## Free Providers


### PR DESCRIPTION
Hi — thanks for maintaining free-llm-api-resources; it's a great directory for getting side projects running on free tiers.

Disclosure: I maintain [ModelPriceWatch](https://modelpricewatch.com/) (an open LLM-API pricing tracker) — flagging per self-promotion norms; totally fine to decline or reword.

A recurring next question for readers here is *"the free quota ran out / I hit the rate limit — what's the cheapest **paid** model now?"*. ModelPriceWatch tracks exactly that: a live cheapest-paid-input figure that auto-updates from provider pricing pages, so it never goes stale.

A couple of notes so this is a clean contribution:
- The README carries a **DO NOT EDIT** banner (it's generated), so I edited **`src/README_template.md`**, not the generated `README.md`.
- I added a single `> [!TIP]` callout matching your existing note/warning style — one do-follow text link to the live `/cheapest/` page, **no badge image, no tracking params, and no hardcoded number** that could go stale.
- I left regenerating `README.md` to your pipeline since it pulls live model data.

Happy to adjust the wording/placement or drop it — no worries either way.
