### PR TITLE
Add AI Router trial-credit provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,14 @@ Extremely restrictive input/output token limits.
 
 **Models:** Various open models
 
+### [AI Router](https://ai-router.dev)
+
+**Credits:** 20U total: 5U available after registration; up to 15U unlocked 1:1 with eligible top-ups. Daily check-in: $1 plus 2% of the previous day's spend
+
+**Requirements:** Registration; top-up is required only to unlock the additional 15U
+
+**Models:** Independent, non-OpenAI-operated managed API relay with an OpenAI-compatible interface; query `/v1/models` for current availability
+
 ### [Hyperbolic](https://app.hyperbolic.ai/)
 
 **Credits:** $1

--- a/src/pull_available_models.py
+++ b/src/pull_available_models.py
@@ -1024,6 +1024,13 @@ def main():
             "requirements": "",
             "models_desc": "Various open models",
         },
+        {
+            "name": "AI Router",
+            "url": "https://ai-router.dev",
+            "credits": "20U total: 5U available after registration; up to 15U unlocked 1:1 with eligible top-ups. Daily check-in: $1 plus 2% of the previous day's spend",
+            "requirements": "Registration; top-up is required only to unlock the additional 15U",
+            "models_desc": "Independent, non-OpenAI-operated managed API relay with an OpenAI-compatible interface; query `/v1/models` for current availability",
+        },
     ]
 
     for provider in trial_providers_static:


### PR DESCRIPTION
## Summary

Adds AI Router under **Providers with trial credits** and updates both the generator source and generated README.

Credit terms are stated conservatively:
- 5U is available after registration
- up to 15U more is unlocked 1:1 with eligible top-ups
- each daily check-in grants $1 plus 2% of the previous day's spend
- the entry is not classified as a permanently free provider

The description also discloses that AI Router is an independent, non-OpenAI-operated managed relay. Current model availability is intentionally delegated to `/v1/models` rather than copied into a static list.

Operator disclosure: this is a self-submission by AI Router. No referral link is used.